### PR TITLE
removed jshint task from build process. can run independently.

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -121,5 +121,5 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-karma');
 
 
-  grunt.registerTask('default', [ 'jshint', 'clean', 'concat', 'babel', 'copy', 'sass']);
+  grunt.registerTask('default', ['clean', 'concat', 'babel', 'copy', 'sass']);
 };


### PR DESCRIPTION
build process was broken due to jshint errors. removed jshint task from build process. can run independently instead.